### PR TITLE
Fix assignment punctuation in intersectLines

### DIFF
--- a/src/core/GeomTools.cpp
+++ b/src/core/GeomTools.cpp
@@ -391,7 +391,7 @@ void intersectLines( const Vec3& o1, const Vec3& d1, const Vec3& o2, const Vec3&
 
    if( sqrlen < parallelThreshold )
    {
-      s = real(0),
+      s = real(0);
       t = real(0);
    }
    else


### PR DESCRIPTION
## Summary
- fix punctuation in `intersectLines` to use separate statements for `s` and `t`

## Testing
- `git show -n 1 src/core/GeomTools.cpp`

------
https://chatgpt.com/codex/tasks/task_e_684153792040832096bbd04aed6e7ecd