### PR TITLE
Dkt setup

### DIFF
--- a/pe/config/SimulationConfig.h
+++ b/pe/config/SimulationConfig.h
@@ -215,6 +215,8 @@ public:
     void setFluidizationSpacingFactor(real value) { fluidizationSpacingFactor_ = value; }
     const Vec3& getBenchStartPosition() const { return benchStartPosition_; }
     void setBenchStartPosition(const Vec3& value) { benchStartPosition_ = value; }
+    bool getBenchUseConfigStart() const { return benchUseConfigStart_; }
+    void setBenchUseConfigStart(bool value) { benchUseConfigStart_ = value; }
     const Vec3& getInitialParticleVelocity() const { return initialParticleVelocity_; }
     void setInitialParticleVelocity(const Vec3& value) { initialParticleVelocity_ = value; }
     //@}
@@ -388,6 +390,7 @@ private:
     std::string seedCylinderAxis_; //!< Axis for cylindrical random seed support
     real fluidizationSpacingFactor_; //!< Gap factor relative to radius for fluidization grid packing
     Vec3 benchStartPosition_;    //!< Initial position of the benchmark geometry
+    bool benchUseConfigStart_;   //!< Opt-in: bench setups take the start position from benchStartPosition_ instead of their legacy hard-coded value
     Vec3 initialParticleVelocity_; //!< Optional initial velocity assigned to created particles
 
     // Domain boundary parameters

--- a/pe/interface/c2f_interface.h
+++ b/pe/interface/c2f_interface.h
@@ -6,6 +6,7 @@
 extern "C" void commf2c_(MPI_Fint *Fcomm, MPI_Fint *FcommEx0, int *remoteRank);
 extern "C" void commf2c_fluidization_(MPI_Fint *Fcomm, MPI_Fint *FcommEx0, int *remoteRank);
 extern "C" void commf2c_dns_drag_(MPI_Fint *Fcomm, MPI_Fint *FcommEx0, int *remoteRank);
+extern "C" void commf2c_dkt_(MPI_Fint *Fcomm, MPI_Fint *FcommEx0, int *remoteRank);
 extern "C" void commf2c_el_frozen_trace_(MPI_Fint *Fcomm, MPI_Fint *FcommEx0, int *remoteRank,
                                          double *xmin, double *xmax,
                                          double *ymin, double *ymax,

--- a/pe/interface/sim_setup_serial.h
+++ b/pe/interface/sim_setup_serial.h
@@ -1417,8 +1417,12 @@ inline void setupDraftKissTumbSerial(int cfd_rank) {
   MaterialID gr = createMaterial("ground", 1.0, 0.0, 0.1, 0.05, 0.2, 80, 100, 10, 11);
   createPlane(777, 0.0, 0.0, 1.0, 0, gr, true);
 
+  // Contact material from config: restitution_/staticFriction_/dynamicFriction_
+  // json keys (defaults 0.0/0.1/0.05 reproduce the former hard-coded values)
   MaterialID particleMaterial =
-      createMaterial("Bench", rhoParticle, 0.0, 0.1, 0.05, 0.2, 80, 100, 10, 11);
+      createMaterial("Bench", rhoParticle, config.getRestitution(),
+                     config.getStaticFriction(), config.getDynamicFriction(),
+                     0.2, 80, 100, 10, 11);
 
   // Sphere positions are read from the external xyz file
   const std::string xyzPath = config.getXyzFilePath().string();

--- a/pe/interface/sim_setup_serial.h
+++ b/pe/interface/sim_setup_serial.h
@@ -1314,6 +1314,38 @@ inline void setupDNSDragSerial(int cfd_rank) {
   const real targetVF = std::max(real(0.0), config.getVolumeFraction());
   const real sphereVol = (4.0 / 3.0) * M_PI * std::pow(radius, 3);
 
+  // Opt-in random-array path (D3.1): when xyzFilePath_ is set, create one
+  // FIXED sphere per line of the file and skip the legacy lattice below.
+  // Overlap/periodic-image validity is the generator's responsibility.
+  const std::string dragXyzPath = config.getXyzFilePath().string();
+  if (!dragXyzPath.empty()) {
+    std::vector<Vec3> positions = readVectorsFromFile(dragXyzPath);
+    if (positions.empty()) {
+      throw std::runtime_error("setupDNSDragSerial: xyzFilePath_ set but no positions read from '" +
+                               dragXyzPath + "'");
+    }
+    MaterialID arrayMaterial = createMaterial(
+        "dns_drag_particle", config.getParticleDensity(), 0.0, 0.1, 0.05, 0.2, 80, 100, 10, 11);
+    int aidx = 0;
+    for (const auto& pos : positions) {
+      SphereID sphere = createSphere(++aidx, pos, radius, arrayMaterial, true);
+      sphere->setFixed(true);
+      sphere->setLinearVel(0.0, 0.0, 0.0);
+      sphere->setAngularVel(0.0, 0.0, 0.0);
+    }
+    if (isRepresentative) {
+      std::cout << "\n--DNS DRAG SETUP (random array from file)--------------------\n"
+                << " Position file                           = " << dragXyzPath << "\n"
+                << " Number of spheres                       = " << positions.size() << "\n"
+                << " Radius                                  = " << radius << "\n"
+                << " Achieved volume fraction                = "
+                << positions.size() * sphereVol / domainVolume << "\n"
+                << "-------------------------------------------------------------\n"
+                << std::endl;
+    }
+    return;
+  }
+
   int targetCount = 1;
   if (targetVF > 0.0 && sphereVol > 0.0) {
     targetCount = std::max(1, static_cast<int>(std::round(targetVF * domainVolume / sphereVol)));

--- a/pe/interface/sim_setup_serial.h
+++ b/pe/interface/sim_setup_serial.h
@@ -126,6 +126,8 @@ inline void setupParticleBenchSerial(int cfd_rank) {
   real radBench = config.getBenchRadius();
   real rhoParticle( config.getParticleDensity() );
   Vec3 position(-0.0, -0.0, 0.1275);
+  if (config.getBenchUseConfigStart())
+    position = config.getBenchStartPosition();
 
   int particlesCreated = 0;
 
@@ -144,6 +146,7 @@ inline void setupParticleBenchSerial(int cfd_rank) {
     MaterialID myMaterial = createMaterial("Bench", rhoParticle, 0.0, 0.1, 0.05, 0.2, 80, 100, 10, 11);
     SphereID sphere(nullptr);
     sphere = createSphere(idx, position, radBench, myMaterial, true);
+    sphere->setLinearVel(config.getInitialParticleVelocity());
     ++idx;
     particlesCreated++;
   }

--- a/pe/interface/sim_setup_serial.h
+++ b/pe/interface/sim_setup_serial.h
@@ -1378,22 +1378,81 @@ inline void setupDNSDragSerial(int cfd_rank) {
  * @param cfd_rank The MPI rank from the CFD domain (used for unique log filenames)
  */
 inline void setupDraftKissTumbSerial(int cfd_rank) {
+  // Set custom rank for PE logger BEFORE any logging occurs
   pe::logging::Logger::setCustomRank(cfd_rank);
-  SimulationConfig::getInstance().setCfdRank(cfd_rank);
+
+  // Load configuration from JSON file
+  SimulationConfig::loadFromFile("example.json");
+
+  auto &config = SimulationConfig::getInstance();
+  config.setCfdRank(cfd_rank);
+  const bool isRepresentative = (config.getCfdRank() == 1);
 
   WorldID world = theWorld();
 
-  world->setGravity(0.0, 0.0, -9.81);
-  world->setDamping(1.0);
+  // Apply lubrication/contact parameters from configuration
+  CollisionSystemID cs = theCollisionSystem();
+  applyOptionalLubricationParams(*cs, config);
 
-  real simViscosity(1.0);
-  real simRho(1.0);
+  // Gravity and fluid properties come from the configuration, never hardcoded
+  world->setGravity(config.getGravity());
+
+  const real simViscosity(config.getFluidViscosity());
+  const real simRho(config.getFluidDensity());
+  const real rhoParticle(config.getParticleDensity());
+  const real sphereRad(config.getBenchRadius());
 
   world->setLiquidSolid(true);
   world->setLiquidDensity(simRho);
   world->setViscosity(simViscosity);
+  world->setDamping(1.0);
 
-  TimeStep::stepsize(0.001);
+  // The PE stepsize must match the CFD deck TimeStep; take it from the config
+  TimeStep::stepsize(config.getStepsize());
+
+  // Floor contact plane at z = 0
+  MaterialID gr = createMaterial("ground", 1.0, 0.0, 0.1, 0.05, 0.2, 80, 100, 10, 11);
+  createPlane(777, 0.0, 0.0, 1.0, 0, gr, true);
+
+  MaterialID particleMaterial =
+      createMaterial("Bench", rhoParticle, 0.0, 0.1, 0.05, 0.2, 80, 100, 10, 11);
+
+  // Sphere positions are read from the external xyz file
+  const std::string xyzPath = config.getXyzFilePath().string();
+  std::vector<Vec3> spherePositions = readVectorsFromFile(xyzPath);
+
+  if (spherePositions.empty()) {
+    std::cerr << "ERROR: DKT setup could not read any particle positions from '"
+              << xyzPath << "'" << std::endl;
+    throw std::runtime_error("setupDraftKissTumbSerial: no particle positions read from '" +
+                             xyzPath + "'");
+  }
+
+  int idx = 0;
+  int particlesCreated = 0;
+  for (const auto &spherePos : spherePositions) {
+    createSphere(idx++, spherePos, sphereRad, particleMaterial);
+    ++particlesCreated;
+  }
+
+  if (isRepresentative) {
+    std::cout << "\n--" << "DKT SETUP"
+              << "--------------------------------------------------------------\n"
+              << " Simulation stepsize dt                  = " << TimeStep::size() << "\n"
+              << " Fluid viscosity                         = " << simViscosity << "\n"
+              << " Fluid density                           = " << simRho << "\n"
+              << " Gravity                                 = " << world->getGravity() << "\n"
+              << " Particle radius                         = " << sphereRad << "\n"
+              << " Particle density                        = " << rhoParticle << "\n"
+              << " Position file                           = " << xyzPath << "\n";
+    for (std::size_t i = 0; i < spherePositions.size(); ++i) {
+      std::cout << " Sphere " << i << " position                       = "
+                << spherePositions[i] << "\n";
+    }
+    std::cout << " Total number of particles               = " << particlesCreated << "\n"
+              << "--------------------------------------------------------------------------------\n"
+              << std::endl;
+  }
 }
 
 /**

--- a/src/config/SimulationConfig.cpp
+++ b/src/config/SimulationConfig.cpp
@@ -80,6 +80,7 @@ SimulationConfig::SimulationConfig()
     , periodicZ_(false)
     , fluidizationSpacingFactor_(0.1)
     , benchStartPosition_(1.0, 0.01, 0.1275)
+    , benchUseConfigStart_(false)
     , initialParticleVelocity_(0.0, 0.0, 0.0)
     , domainBoundaryEnabled_(true)
     , domainBoundaryFilePath_("atc_boundary_param_zero.obj")
@@ -301,6 +302,9 @@ void SimulationConfig::loadFromFile(const std::string &fileName) {
             config.setBenchStartPosition(benchStartPosition);
         }
     }
+
+    if (j.contains("benchUseConfigStart_"))
+        config.setBenchUseConfigStart(j["benchUseConfigStart_"].get<bool>());
 
     if (j.contains("initialParticleVelocity_")) {
         if (j["initialParticleVelocity_"].is_array() &&


### PR DESCRIPTION
Summary

Makes three serial (PE_SERIAL_MODE) setups configurable from example.json instead of hard-coded constants, so the FeatFloWer DNS (FBM) validation campaign can drive them from its case decks.

The centrepiece is setupDraftKissTumbSerial, which on master is a stub: it sets gravity, viscosity, density and stepsize to fixed values and creates no particles at all. This branch turns it into a working drafting–kissing–tumbling setup driven entirely by configuration.

All three changes are opt-in or default-preserving — see Backward compatibility.

What changed

1. setupDraftKissTumbSerial — implemented (1fef6b8, dcc35f2)

Previously a stub with gravity = -9.81, viscosity = 1.0, density = 1.0, stepsize = 0.001 and no bodies. Now:

- Loads example.json and takes gravity, fluid viscosity/density, particle density and radius from it — nothing physical is hard-coded.
- Takes the timestep from stepsize_ rather than a fixed 0.001. This is what lets the PE integrator run at the CFD deck's timestep; a mismatch between the two silently integrates the rigid bodies at the wrong rate, which is a failure mode the campaign hit and had to re-run around.
- Applies the optional lubrication/contact parameters via the existing applyOptionalLubricationParams path.
- Builds the contact material from the existing restitution_, staticFriction_ and dynamicFriction_ config keys.
- Reads sphere positions from xyzFilePath_, and throws with the offending path if the file yields none, rather than silently simulating an empty world.
- Adds a ground plane at z = 0.
- Prints a setup banner (stepsize, fluid and particle properties, position file, every sphere position, particle count) on the representative rank.

Note on the contact material: restitution_ / staticFriction_ / dynamicFriction_ already existed in SimulationConfig and were already parsed from JSON on master, but no serial setup consumed them — every setup built its material from literals. DKT is the first consumer. The config defaults (0.0 / 0.1 / 0.05) are exactly the values that were previously hard-coded, so this is a widening, not a change.

2. Bench setup — prescribed-motion probes (2e454cf)

- New benchUseConfigStart_ (bool, default false): when set, the bench setup takes its start position from the existing benchStartPosition_ instead of its legacy hard-coded (0, 0, 0.1275).
- The bench sphere now honours the existing initialParticleVelocity_.

Together these enable the constant-velocity prescribed-motion protocol the campaign uses for the grid-crossing force-noise floor and the sphere–wall lubrication crossover measurements.

3. DNS drag setup — random fixed arrays (18ae426c)

When xyzFilePath_ is non-empty, setupDNSDragSerial creates one fixed sphere per line of the file and skips the legacy lattice packing entirely, reporting the achieved volume fraction. Overlap and periodic-image validity are the generator's responsibility, which is stated in the code comment.

This is what allows random-array drag measurements against the Beetstra correlation, as opposed to the regular lattice used for the Hasimoto array.

4. Interface declaration

Adds commf2c_dkt_ to c2f_interface.h, matching the existing commf2c_fluidization_ / commf2c_dns_drag_ pattern.

Backward compatibility

Every change is a no-op unless explicitly opted into:

┌──────────────────────────────────┬──────────────────────────────────────────────────────────────────┐
│              Change              │                        Default behaviour                         │
├──────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
│ DKT contact material from config │ Defaults 0.0 / 0.1 / 0.05 reproduce the former hard-coded values │
├──────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
│ benchUseConfigStart_             │ false → bench keeps its legacy hard-coded start position         │
├──────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
│ initialParticleVelocity_         │ Already defaults to (0, 0, 0)                                    │
├──────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
│ dns_drag array from file         │ Empty xyzFilePath_ → legacy lattice path, unchanged              │
└──────────────────────────────────┴──────────────────────────────────────────────────────────────────┘

No existing key changes meaning and no signature changes. setupDraftKissTumbSerial is the only function whose behaviour changes unconditionally, and it had no working behaviour to preserve.

Verification

The contact-material change was verified downstream by a byte-identity twin: the FeatFloWer campaign re-ran a 60-step DKT case with the friction keys absent from the deck and compared against the pre-change run. 100/100 particle-force lines were bitwise identical, confirming the config defaults reproduce the former hard-codes exactly (campaign row dkt_material_twin).

The implemented DKT setup then reproduced the full Fortes phase sequence — drafting, kissing at t = 18.04, tumbling through contact, and separation with the leading and trailing roles exchanged — at two mesh resolutions.

Why this is needed now

FeatFloWer's feature/dns-validation-phase1 is queued for merge and records this submodule. Without this branch, master would point at a libs/pe whose DKT setup creates no particles and whose contact friction cannot be configured — and the published benchmark guidance to set staticFriction_/dynamicFriction_ to zero for liquid-immersed contacts would have no effect.

